### PR TITLE
empty hash to hosts variable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,7 +36,7 @@
 # Copyright 2015 Sebastian Reitenbach, unless otherwise noted.
 #
 class autoinstall (
-  $hosts,
+  $hosts = {},
   $hostsdefaults = undef,
 ) {
 


### PR DESCRIPTION
We need an empty hash here to not fail in case we have hostsdefaults defined in hiera but no hosts.